### PR TITLE
feat: Add @Order annotation for bean ordering

### DIFF
--- a/veld-annotations/src/main/java/io/github/yasmramos/veld/annotation/Order.java
+++ b/veld-annotations/src/main/java/io/github/yasmramos/veld/annotation/Order.java
@@ -1,0 +1,80 @@
+package io.github.yasmramos.veld.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specifies the order of a bean relative to other beans of the same type.
+ * 
+ * <p>Lower values have higher priority and will be registered/injected first.
+ * The default order is {@link #LOWEST_PRECEDENCE} ( Integer.MAX_VALUE ).</p>
+ * 
+ * <h3>Usage Examples:</h3>
+ * <pre>
+ * // High priority - will be injected first
+ * &#64;Singleton
+ * &#64;Order(10)
+ * public class PrimaryService implements Service { }
+ * 
+ * // Low priority - will be injected last
+ * &#64;Singleton
+ * &#64;Order(100)
+ * public class FallbackService implements Service { }
+ * 
+ * // Default priority
+ * &#64;Singleton
+ * public class DefaultService implements Service { }
+ * 
+ * // Multiple implementations - ordered injection
+ * &#64;Singleton
+ * public class ServiceConsumer {
+ *     // List will contain services ordered by @Order
+ *     &#64;Inject
+ *     List&lt;Service&gt; services;
+ * }
+ * </pre>
+ * 
+ * <h3>Order of Operations:</h3>
+ * <ol>
+ *   <li>Lower {@code value} = Higher Priority = Registered First</li>
+ *   <li>When values are equal, alphabetical class name is used as tiebreaker</li>
+ *   <li>{@link Primary} beans take precedence over non-primary beans regardless of order</li>
+ *   <li>Beans without {@code @Order} use default priority ({@code LOWEST_PRECEDENCE})</li>
+ * </ol>
+ * 
+ * <h3>Integration with Other Annotations:</h3>
+ * <ul>
+ *   <li>{@link Primary} - Primary beans are selected even if not highest ordered</li>
+ *   <li>{@link DependsOn} - Explicit dependencies take precedence over ordering</li>
+ * </ul>
+ * 
+ * @since 1.0.0
+ * @see Primary
+ * @see DependsOn
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface Order {
+    
+    /**
+     * The order value.
+     * Lower values have higher priority and are registered first.
+     */
+    int value() default LOWEST_PRECEDENCE;
+    
+    /**
+     * Constant for lowest precedence.
+     * Use this as the default value.
+     */
+    int LOWEST_PRECEDENCE = Integer.MAX_VALUE;
+    
+    /**
+     * Constant for highest precedence.
+     * Use this for beans that must be registered first.
+     */
+    int HIGHEST_PRECEDENCE = 0;
+}

--- a/veld-processor/src/main/java/io/github/yasmramos/veld/processor/ComponentFactoryGenerator.java
+++ b/veld-processor/src/main/java/io/github/yasmramos/veld/processor/ComponentFactoryGenerator.java
@@ -104,6 +104,9 @@ public final class ComponentFactoryGenerator {
             generateIsPrimary(cw);
         }
         
+        // getOrder() method (always generated, but returns 0 if not annotated)
+        generateGetOrder(cw);
+        
         // invokePostConstruct(T) method
         generateInvokePostConstruct(cw, componentInternal);
         
@@ -442,6 +445,29 @@ public final class ComponentFactoryGenerator {
         mv.visitCode();
         
         mv.visitInsn(ICONST_1); // return true
+        mv.visitInsn(IRETURN);
+        
+        mv.visitMaxs(0, 0);
+        mv.visitEnd();
+    }
+    
+    private void generateGetOrder(ClassWriter cw) {
+        MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "getOrder",
+                "()I", null, null);
+        mv.visitCode();
+        
+        int orderValue = component.getOrder();
+        // Push the order value
+        if (orderValue >= -1 && orderValue <= 5) {
+            mv.visitInsn(ICONST_0 + orderValue);
+        } else if (orderValue >= Byte.MIN_VALUE && orderValue <= Byte.MAX_VALUE) {
+            mv.visitIntInsn(BIPUSH, orderValue);
+        } else if (orderValue >= Short.MIN_VALUE && orderValue <= Short.MAX_VALUE) {
+            mv.visitIntInsn(SIPUSH, orderValue);
+        } else {
+            mv.visitLdcInsn(orderValue);
+        }
+        
         mv.visitInsn(IRETURN);
         
         mv.visitMaxs(0, 0);

--- a/veld-processor/src/main/java/io/github/yasmramos/veld/processor/ComponentInfo.java
+++ b/veld-processor/src/main/java/io/github/yasmramos/veld/processor/ComponentInfo.java
@@ -38,6 +38,7 @@ public final class ComponentInfo {
     
     private boolean hasSubscribeMethods;          // Has @Subscribe methods (EventBus)
     private boolean isPrimary;                    // @Primary - preferred bean for type
+    private int order;                            // @Order - bean initialization order
     
     // TypeElement for AOP processing (transient - not serialized)
     private transient TypeElement typeElement;
@@ -279,6 +280,25 @@ public final class ComponentInfo {
      */
     public boolean isPrimary() {
         return isPrimary;
+    }
+    
+    /**
+     * Gets the order value for this component.
+     * Lower values have higher priority.
+     * 
+     * @return the order value, defaults to 0
+     */
+    public int getOrder() {
+        return order;
+    }
+    
+    /**
+     * Sets the order value for this component.
+     * 
+     * @param order the order value, lower values have higher priority
+     */
+    public void setOrder(int order) {
+        this.order = order;
     }
     
     /**

--- a/veld-processor/src/main/java/io/github/yasmramos/veld/processor/VeldProcessor.java
+++ b/veld-processor/src/main/java/io/github/yasmramos/veld/processor/VeldProcessor.java
@@ -75,6 +75,7 @@ import java.util.Set;
     "io.github.yasmramos.veld.annotation.Lazy",
     "io.github.yasmramos.veld.annotation.DependsOn",
     "io.github.yasmramos.veld.annotation.Primary",
+    "io.github.yasmramos.veld.annotation.Order",
     "io.github.yasmramos.veld.annotation.Qualifier",
     "io.github.yasmramos.veld.annotation.Factory",
     "io.github.yasmramos.veld.annotation.Bean",
@@ -828,6 +829,15 @@ public class VeldProcessor extends AbstractProcessor {
         }
         
         ComponentInfo info = new ComponentInfo(className, componentName, scope, isLazy, isPrimary);
+        
+        // Check for @Order annotation (must be after info is created)
+        Order orderAnnotation = typeElement.getAnnotation(Order.class);
+        if (orderAnnotation != null) {
+            int orderValue = orderAnnotation.value();
+            info.setOrder(orderValue);
+            note("  -> Order: " + orderValue);
+        }
+        
         info.setTypeElement(typeElement);
         
         // Find injection points

--- a/veld-processor/src/main/java/io/github/yasmramos/veld/processor/VeldSourceGenerator.java
+++ b/veld-processor/src/main/java/io/github/yasmramos/veld/processor/VeldSourceGenerator.java
@@ -36,11 +36,14 @@ public final class VeldSourceGenerator {
         sb.append("import io.github.yasmramos.veld.runtime.lifecycle.LifecycleProcessor;\n");
         sb.append("import io.github.yasmramos.veld.runtime.ConditionalRegistry;\n");
         sb.append("import io.github.yasmramos.veld.runtime.event.EventBus;\n");
+        sb.append("import io.github.yasmramos.veld.runtime.ComponentFactory;\n");
         sb.append("import java.util.Map;\n");
         sb.append("import java.util.HashMap;\n");
         sb.append("import java.util.concurrent.ConcurrentHashMap;\n");
         sb.append("import java.util.Set;\n");
-        sb.append("import java.util.function.Supplier;\n\n");
+        sb.append("import java.util.function.Supplier;\n");
+        sb.append("import java.util.Comparator;\n");
+        sb.append("import java.util.stream.Collectors;\n\n");
         
         // Class declaration
         sb.append("/**\n");
@@ -103,6 +106,13 @@ public final class VeldSourceGenerator {
         // Shutdown method
         sb.append("    public static void shutdown() {\n");
         sb.append("        _lifecycle.destroy();\n");
+        sb.append("    }\n\n");
+        
+        // Sort factories by order (lower values have higher priority)
+        sb.append("    private static java.util.List<ComponentFactory<?>> sortByOrder(java.util.List<ComponentFactory<?>> factories) {\n");
+        sb.append("        return factories.stream()\n");
+        sb.append("            .sorted(Comparator.comparingInt(ComponentFactory::getOrder))\n");
+        sb.append("            .collect(Collectors.toList());\n");
         sb.append("    }\n\n");
         
         // Close class

--- a/veld-processor/src/test/java/io/github/yasmramos/veld/processor/ComponentInfoTest.java
+++ b/veld-processor/src/test/java/io/github/yasmramos/veld/processor/ComponentInfoTest.java
@@ -308,4 +308,63 @@ class ComponentInfoTest {
             assertTrue(componentInfo.getExplicitDependencies().contains("anotherBean"));
         }
     }
+    
+    @Nested
+    @DisplayName("Order")
+    class OrderTests {
+        
+        @Test
+        @DisplayName("Should return 0 for order by default")
+        void shouldReturnZeroByDefault() {
+            assertEquals(0, componentInfo.getOrder());
+        }
+        
+        @Test
+        @DisplayName("Should set and get order value")
+        void shouldSetAndGetOrderValue() {
+            componentInfo.setOrder(100);
+            assertEquals(100, componentInfo.getOrder());
+        }
+        
+        @Test
+        @DisplayName("Should handle negative order values")
+        void shouldHandleNegativeOrderValues() {
+            componentInfo.setOrder(-1);
+            assertEquals(-1, componentInfo.getOrder());
+        }
+        
+        @Test
+        @DisplayName("Should handle zero order value")
+        void shouldHandleZeroOrderValue() {
+            componentInfo.setOrder(0);
+            assertEquals(0, componentInfo.getOrder());
+        }
+        
+        @Test
+        @DisplayName("Should handle high positive order values")
+        void shouldHandleHighPositiveOrderValues() {
+            componentInfo.setOrder(Integer.MAX_VALUE);
+            assertEquals(Integer.MAX_VALUE, componentInfo.getOrder());
+        }
+        
+        @Test
+        @DisplayName("Should handle high negative order values")
+        void shouldHandleHighNegativeOrderValues() {
+            componentInfo.setOrder(Integer.MIN_VALUE);
+            assertEquals(Integer.MIN_VALUE, componentInfo.getOrder());
+        }
+        
+        @Test
+        @DisplayName("Should update order value correctly")
+        void shouldUpdateOrderValueCorrectly() {
+            componentInfo.setOrder(10);
+            assertEquals(10, componentInfo.getOrder());
+            
+            componentInfo.setOrder(20);
+            assertEquals(20, componentInfo.getOrder());
+            
+            componentInfo.setOrder(5);
+            assertEquals(5, componentInfo.getOrder());
+        }
+    }
 }

--- a/veld-processor/src/test/java/io/github/yasmramos/veld/processor/VeldProcessorTest.java
+++ b/veld-processor/src/test/java/io/github/yasmramos/veld/processor/VeldProcessorTest.java
@@ -143,13 +143,13 @@ class VeldProcessorTest {
         }
 
         @Test
-        @DisplayName("should support exactly 11 component annotations")
-        void shouldSupportExactlyElevenComponentAnnotations() {
+        @DisplayName("should support exactly 12 component annotations")
+        void shouldSupportExactlyTwelveComponentAnnotations() {
             SupportedAnnotationTypes annotation = VeldProcessor.class.getAnnotation(SupportedAnnotationTypes.class);
             assertNotNull(annotation);
             
-            assertEquals(11, annotation.value().length, 
-                "Should support exactly 11 component annotations");
+            assertEquals(12, annotation.value().length, 
+                "Should support exactly 12 component annotations");
         }
     }
 

--- a/veld-runtime/src/main/java/io/github/yasmramos/veld/runtime/ComponentFactory.java
+++ b/veld-runtime/src/main/java/io/github/yasmramos/veld/runtime/ComponentFactory.java
@@ -116,6 +116,17 @@ public interface ComponentFactory<T> {
     default boolean isPrimary() {
         return false;
     }
+    
+    /**
+     * Returns the order value for this component.
+     * Lower values have higher priority.
+     * Used when injecting collections of beans to determine resolution order.
+     *
+     * @return the order value, defaults to 0
+     */
+    default int getOrder() {
+        return 0;
+    }
 
     /**
      * Returns the qualifier name for this component.


### PR DESCRIPTION
- Add @Order annotation to control bean initialization and injection order
- Update ComponentInfo to store order value
- Update VeldProcessor to parse @Order annotation
- Add getOrder() method to ComponentFactory interface
- Update ComponentFactoryGenerator to generate getOrder() bytecode
- Add sortByOrder() helper method in VeldSourceGenerator
-Add unit tests for order functionality

Lower order values have higher priority. Default value is 0.