### PR TITLE
Normalize pull request templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
@@ -42,6 +42,7 @@ Describe los cambios específicos que solucionan el bug.
 - [ ] `veld-processor`
 - [ ] `veld-aop`
 - [ ] `veld-benchmark`
+- [ ] Otros (especificar)
 
 ## 🧪 Validación
 
@@ -62,10 +63,11 @@ Describe los cambios específicos que solucionan el bug.
 
 ## ✅ Checklist
 - [ ] Bug reproducible identificado y corregido
-- [ ] Tests agregados para prevenir regresión
+- [ ] Tests agregados o actualizados según corresponda
 - [ ] Casos de prueba validados
 - [ ] Documentación actualizada si es necesario
 - [ ] Auto-review completado
+- [ ] Cumple las convenciones de contribución
 
 ---
 *Bug Fix PR template - Revisar [guía de contribución](./CONTRIBUTING.md)*

--- a/.github/PULL_REQUEST_TEMPLATE/documentation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/documentation.md
@@ -1,98 +1,32 @@
 # 📚 Documentación
 
 ## 📝 Resumen
-Descripción de qué documentación se está creando, actualizando o mejorando.
+Qué documentación se crea/actualiza y el objetivo.
 
-## 📖 Tipo de Documentación
+## 📖 Alcance
+- [ ] README/Guías rápidas
+- [ ] Guía de usuario
+- [ ] Guía de desarrollador
+- [ ] API/Referencia
+- [ ] Ejemplos/Código de muestra
+- [ ] Migraciones/Notas de versión
+- [ ] Otros (especificar)
 
-### Documentos Afectados
-- [ ] **README** - Documentación principal del proyecto
-- [ ] **Javadoc** - Documentación de código Java
-- [ ] **API Documentation** - Documentación de APIs
-- [ ] **User Guide** - Guía para usuarios finales
-- [ ] **Developer Guide** - Guía para desarrolladores
-- [ ] **Migration Guide** - Guía de migración
-- [ ] **Examples** - Ejemplos de código
-- [ ] **Architecture** - Documentación de arquitectura
-- [ ] **CONTRIBUTING** - Guía de contribución
-- [ ] **Otro**: _______________
+Cambios principales:
+- …
 
-## 🎯 Objetivos
-
-### ¿Qué problema resuelve esta documentación?
-Describe qué gap de información se está cubriendo.
-
-### Audiencia Objetivo
-- [ ] **Desarrolladores** - Para usar el framework
-- [ ] **Contributors** - Para contribuir al proyecto
-- [ ] **Users** - Para usar Veld en sus aplicaciones
-- [ ] **DevOps** - Para deployment y configuración
-- [ ] **Stakeholders** - Para entender el proyecto
-
-## 📋 Contenido Actualizado
-
-### Nuevas Secciones
-Lista las nuevas secciones o capítulos agregados.
-
-### Secciones Modificadas
-Lista las secciones existentes que fueron actualizadas.
-
-### Secciones Eliminadas
-Lista cualquier contenido que fue removido.
-
-## 🔍 Cambios Específicos
-
-### Ejemplos de Código
-- [ ] Ejemplos agregados
-- [ ] Ejemplos actualizados
-- [ ] Ejemplos corregidos
-- [ ] Screenshots/diagramas agregados
-
-### Enlaces y Referencias
-- [ ] Enlaces internos actualizados
-- [ ] Enlaces externos verificados
-- [ ] Referencias cruzadas agregadas
-
-## ✅ Checklist de Calidad
-
-### Consistencia
-- [ ] Estilo consistente con documentación existente
-- [ ] Formato consistente en todo el documento
-- [ ] Terminología consistente
-
-### Completitud
-- [ ] Toda incluida la información necesaria
-- [ ] Ejemplos funcionales y probados
-- [ ] Enlaces funcionando correctamente
-
-### Claridad
-- [ ] Lenguaje claro y conciso
-- [ ] Estructura lógica y fácil de seguir
-- [ ] Conceptos complejos explicados
-
-## 🧪 Validación
-
-### Revisiones
-- [ ] Auto-review completado
-- [ ] Documentación generada/probada
+## 🧪 Pruebas
 - [ ] Enlaces verificados
-- [ ] Ejemplos compilados y probados
+- [ ] Ejemplos probados/compilados
+- [ ] Documentación generada localmente (si aplica)
+- [ ] Revisión ortográfica/estilo
 
-### Accessibility
-- [ ] Imágenes con alt text
-- [ ] Enlaces descriptivos
-- [ ] Estructura de headings correcta
-
-## 📊 Métricas (si aplica)
-- **Palabras agregadas**: ~X palabras
-- **Secciones nuevas**: X secciones
-- **Ejemplos agregados**: X ejemplos
-- **Screenshots/diagramas**: X imágenes
+## ✅ Checklist
+- [ ] Contenido claro y actualizado
+- [ ] Estructura y formato consistentes con el proyecto
+- [ ] Auto-review completada
+- [ ] Referencias/links añadidos
 
 ## 🔗 Referencias
-- Documentos relacionados actualizados
-- Issues resueltos: #(números)
-- Commits relacionados: (SHA)
-
----
-*Documentation PR template - Revisar [estándares de documentación](./CONTRIBUTING.md)*
+- Issue relacionado: #(número del issue)
+- Recursos/ADR: …

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,51 +1,32 @@
 # 🆕 Nueva Feature
 
 ## 📝 Resumen
-Descripción clara y concisa de la nueva funcionalidad.
+Breve descripción de la funcionalidad y el problema que resuelve.
 
-## 🎯 Objetivo
-¿Qué problema resuelve esta feature? ¿Cuál es el valor que aporta?
+## 🔄 Cambios
+- [ ] API/contratos
+- [ ] Implementación interna
+- [ ] Documentación
+- [ ] Workflows/CI
+- [ ] Otros (especificar)
 
-## 🏗️ Diseño/Arquitectura
-Describe el diseño técnico o los cambios arquitectónicos realizados.
+Detalles de los cambios principales:
+- …
 
-## 📦 Módulos Afectados
-- [ ] `veld-annotations`
-- [ ] `veld-runtime`
-- [ ] `veld-processor`
-- [ ] `veld-aop`
-- [ ] `veld-benchmark`
-
-## 🧪 Plan de Pruebas
-
-### Tests Unitarios
-Describe qué tests unitarios se implementaron o actualizaron.
-
-### Tests de Integración
-Describe los tests de integración si es aplicable.
-
-### Benchmarks
-¿Esta feature requiere benchmarks? ¿Cómo afecta el rendimiento?
-
-## 📚 Documentación
-- [ ] Javadoc actualizado
-- [ ] README actualizado
-- [ ] Guías de usuario
-- [ ] Ejemplos de código
-
-## 🔧 Configuración
-¿Se requiere configuración adicional para usar esta feature?
-
-## 🌍 Compatibilidad
-- ¿Es compatible con versiones anteriores?
-- ¿Requiere cambios de API?
+## 🧪 Pruebas
+- [ ] Tests unitarios
+- [ ] Tests de integración
+- [ ] Pruebas manuales
+- [ ] Benchmarks (si aplica)
+- [ ] No requiere pruebas adicionales (explicar)
 
 ## ✅ Checklist
-- [ ] Código sigue convenciones del proyecto
-- [ ] Tests implementados y pasando
-- [ ] Documentación actualizada
-- [ ] Benchmarks ejecutados (si aplica)
-- [ ] Auto-review completado
+- [ ] Cumple las convenciones del proyecto
+- [ ] Auto-review completada
+- [ ] Documentación actualizada si aplica
+- [ ] Tests agregados/actualizados según corresponda
+- [ ] Sección de referencias completada
 
----
-*Feature PR template - Revisar [guía de contribución](./CONTRIBUTING.md)*
+## 🔗 Referencias
+- Issue relacionado: #(número del issue)
+- Documentación/recursos: …

--- a/.github/PULL_REQUEST_TEMPLATE/hotfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/hotfix.md
@@ -1,73 +1,31 @@
 # 🔥 Hotfix Urgente
 
-## 🚨 Información Crítica
-- [ ] **Es un fix urgente** para producción
-- [ ] **Requiere release inmediato**
-- [ ] **Impacto crítico** en usuarios
+## 🚨 Resumen
+Qué problema crítico se corrige y por qué es urgente.
 
-## 📝 Resumen
-Descripción concisa del problema crítico y la solución.
+## 🔄 Alcance del Cambio
+- [ ] Producción impactada
+- [ ] Fix temporal
+- [ ] Requiere release inmediato
+- [ ] Mitigación aplicada
 
-## ⚠️ Severidad
-- [ ] **Crítico** - Sistema no funcional
-- [ ] **Alto** - Funcionalidad principal afectada
-- [ ] **Medio** - Funcionalidad secundaria afectada
-- [ ] **Bajo** - Problema menor
+Detalles de la solución:
+- …
 
-## 🐛 Problema Identificado
-
-### Descripción del Issue
-¿Qué está fallando? ¿Cómo afecta a los usuarios?
-
-### Impacto en Producción
-- ¿Cuántos usuarios se ven afectados?
-- ¿Qué funcionalidades están rotas?
-- ¿Hay workaround disponible?
-
-## 🔧 Solución
-
-### Cambio Mínimo
-Describe el cambio mínimo necesario para resolver el problema.
-
-### Módulos Afectados
-- [ ] `veld-annotations`
-- [ ] `veld-runtime`
-- [ ] `veld-processor`
-- [ ] `veld-aop`
-- [ ] `veld-benchmark`
-
-## 🧪 Validación Rápida
-
-### Pruebas Críticas
-- [ ] Funcionalidad principal verificada
-- [ ] No se introdujeron regresiones
-- [ ] Performance no degradada
-
-### Deploy/Testing
-- [ ] Probado en entorno de staging
-- [ ] Ready para deploy inmediato
-- [ ] Rollback plan preparado
-
-## 📋 Aprobación de Emergencia
-
-### Aprobado por
-- [ ] **Product Owner**: @usuario
-- [ ] **Tech Lead**: @usuario
-- [ ] **DevOps**: @usuario
-
-### Release Information
-- **Versión target**: vX.Y.Z
-- **Branch target**: main
-- **Release date**: YYYY-MM-DD
+## 🧪 Pruebas
+- [ ] Caso que fallaba verificado
+- [ ] Tests unitarios relevantes
+- [ ] Pruebas manuales en entorno afectado
+- [ ] Sin pruebas (explicar)
 
 ## ✅ Checklist
-- [ ] Solución mínima y segura implementada
-- [ ] Validación básica completada
-- [ ] Aprobaciones obtenidas
-- [ ] Ready para merge inmediato
-- [ ] Comunicación a stakeholders enviada
+- [ ] Riesgos evaluados y aceptados
+- [ ] Cambios mínimos necesarios
+- [ ] Plan de rollback definido (si aplica)
+- [ ] Auto-review completada
+- [ ] Documentación/notas de despliegue actualizadas (si aplica)
 
----
-**⚠️ PROCESO ACELERADO - Merge tan pronto como sea posible**
-
-*Hotfix PR template - Para issues críticos en producción*
+## 🔗 Referencias
+- Issue relacionado: #(número del issue)
+- Incidente/alerta: …
+- Documentación/Runbook: …

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,70 +1,31 @@
 # 🎯 Descripción del Pull Request
 
 ## 📝 Resumen
-Describe brevemente qué cambios introduce este PR y por qué son necesarios.
+Breve descripción de los cambios y la motivación.
 
 ## 🔄 Tipo de Cambio
-- [ ] 🆕 **Feature** - Nueva funcionalidad
-- [ ] 🐛 **Bug Fix** - Corrección de bug
-- [ ] 🔥 **Hotfix** - Corrección urgente
-- [ ] ♻️ **Refactor** - Refactorización de código
-- [ ] 📚 **Documentation** - Documentación
-- [ ] ✅ **Test** - Pruebas y tests
-- [ ] 🏗️ **Build** - Cambios de build/configuración
-
-## 🧪 Cambios Propuestos
-
-### ¿Qué se cambió?
-Describe los cambios específicos realizados.
-
-### ¿Por qué es necesario?
-Explica la motivación detrás de estos cambios.
-
-### 🖼️ Screenshots (si aplica)
-Agrega screenshots que muestren los cambios visuales o de comportamiento.
-
-## 🔍 Detalles Técnicos
-
-### Áreas afectadas
-- [ ] `veld-annotations`
-- [ ] `veld-runtime`
-- [ ] `veld-processor`
-- [ ] `veld-aop`
-- [ ] `veld-benchmark`
-- [ ] Documentación
-- [ ] Workflows/CI
-
-### Dependencias
-¿Este PR introduce nuevas dependencias o cambia las existentes?
-
-## ✅ Checklist de Verificación
-
-- [ ] Mi código sigue las convenciones del proyecto
-- [ ] He realizado auto-review de mi código
-- [ ] He agregado comentarios para código complejo
-- [ ] He actualizado la documentación si es necesario
-- [ ] Los tests pasan localmente
-- [ ] He agregado o actualizado tests si es necesario
-- [ ] Este PR está listo para revisión
+- [ ] 🆕 Feature
+- [ ] 🐛 Bug Fix
+- [ ] 🔥 Hotfix
+- [ ] ♻️ Refactor
+- [ ] 📚 Documentación
+- [ ] ✅ Tests
+- [ ] 🏗️ Build/CI
 
 ## 🧪 Pruebas
-
-### ¿Cómo se probaron los cambios?
-Describe las pruebas realizadas para validar los cambios.
-
-### Casos de prueba específicos
 - [ ] Tests unitarios
 - [ ] Tests de integración
-- [ ] Benchmarks (si aplica)
 - [ ] Pruebas manuales
+- [ ] Benchmarks (si aplica)
+- [ ] Sin pruebas (explicar)
 
-## 📋 Notas Adicionales
-Agrega cualquier información adicional que sea relevante para los reviewers.
+## ✅ Checklist
+- [ ] Cumple las convenciones del proyecto
+- [ ] Auto-review completada
+- [ ] Documentación actualizada si aplica
+- [ ] Tests agregados/actualizados según corresponda
+- [ ] Referencias completadas
 
 ## 🔗 Referencias
 - Issue relacionado: #(número del issue)
-- Documentación relacionada: (enlaces)
-- Commits relacionados: (SHA o referencias)
-
----
-*Este PR sigue las [convenciones del proyecto](./CONTRIBUTING.md)*
+- Documentación/recursos: …

--- a/.github/PULL_REQUEST_TEMPLATE/refactor.md
+++ b/.github/PULL_REQUEST_TEMPLATE/refactor.md
@@ -1,90 +1,30 @@
-# ♻️ Refactoring
+# ♻️ Refactor
 
 ## 📝 Resumen
-Descripción clara de qué se está refactorizando y por qué.
+Qué área se refactoriza y objetivo (legibilidad, deuda técnica, performance).
 
-## 🎯 Objetivos del Refactoring
+## 🔄 Cambios
+- [ ] API sin cambios
+- [ ] Mejora de estructura/código
+- [ ] Simplificación de lógica
+- [ ] Eliminación de código muerto
+- [ ] Otros (especificar)
 
-### Problemas que Resuelve
-- [ ] **Rendimiento** - Optimización de performance
-- [ ] **Mantenibilidad** - Código más fácil de mantener
-- [ ] **Legibilidad** - Código más fácil de entender
-- [ ] **Testabilidad** - Mejor separación de responsabilidades
-- [ ] **Modularidad** - Mejor organización del código
-- [ ] **Debt** - Reducción de technical debt
+Notas sobre el enfoque:
+- …
 
-### Beneficios Esperados
-Describe qué mejoras se esperan obtener.
-
-## 🔍 Análisis del Código Actual
-
-### Áreas de Mejora Identificadas
-Describe qué problemas específicos se identificaron en el código actual.
-
-### Métricas Actuales (si aplica)
-- Complejidad ciclomática
-- Líneas de código
-- Acoplamiento
-- Cohesión
-
-## 🏗️ Nueva Arquitectura
-
-### Cambios Estructurales
-Describe cómo se reorganiza el código.
-
-### Patrones Aplicados
-- [ ] Factory Pattern
-- [ ] Strategy Pattern
-- [ ] Decorator Pattern
-- [ ] Observer Pattern
-- [ ] Dependency Injection
-- [ ] Otro: _______________
-
-### Módulos Afectados
-- [ ] `veld-annotations`
-- [ ] `veld-runtime`
-- [ ] `veld-processor`
-- [ ] `veld-aop`
-- [ ] `veld-benchmark`
-
-## 📊 Comparación Antes/Después
-
-### Mejoras Esperadas
-- **Performance**: X% mejoría en Y metric
-- **Maintainability**: Mejora en Z factor
-- **Testability**: Incremento en coverage del X%
-
-### Compatibilidad
-- [ ] **Backward Compatible** - No breaking changes
-- [ ] **API Changes** - Cambios de API documentados
-- [ ] **Migration Guide** - Guía de migración necesaria
-
-## 🧪 Validación
-
-### Tests de Regresión
-- [ ] Todos los tests existentes siguen pasando
-- [ ] Performance tests ejecutados
-- [ ] Memory usage analizado
-
-### Nuevos Tests
-- [ ] Tests agregados para nueva estructura
-- [ ] Integration tests actualizados
-- [ ] Benchmarks (si performance es crítico)
-
-## 📚 Documentación
-
-### Actualizaciones Necesarias
-- [ ] Javadoc actualizado
-- [ ] README actualizado
-- [ ] Migration guide escrita
-- [ ] Architecture docs actualizadas
+## 🧪 Pruebas
+- [ ] Tests unitarios existentes pasan
+- [ ] Tests de integración relevantes pasan
+- [ ] Nuevos tests agregados si hubo cambios funcionales
+- [ ] Pruebas manuales (si aplica)
 
 ## ✅ Checklist
-- [ ] Refactoring mantiene funcionalidad existente
-- [ ] Tests de regresión pasando
-- [ ] Performance no degradada
-- [ ] Documentación actualizada
-- [ ] Code review completado
+- [ ] Sin cambios de comportamiento intencionados
+- [ ] Auto-review completada
+- [ ] Documentación/comentarios actualizados si aplica
+- [ ] Cumple estándares de estilo
 
----
-*Refactor PR template - Revisar [guía de refactoring](./CONTRIBUTING.md)*
+## 🔗 Referencias
+- Issue relacionado: #(número del issue)
+- Documentación/ADR: …

--- a/.github/PULL_REQUEST_TEMPLATE/test.md
+++ b/.github/PULL_REQUEST_TEMPLATE/test.md
@@ -1,113 +1,30 @@
 # ✅ Actualización de Tests
 
 ## 📝 Resumen
-Descripción de qué cambios se están realizando en los tests.
+Qué cobertura se agrega o mejora y por qué.
 
-## 🧪 Tipo de Cambios en Tests
+## 🔄 Cambios
+- [ ] Nuevos tests unitarios
+- [ ] Nuevos tests de integración
+- [ ] Fixtures/datos de prueba
+- [ ] Infra de pruebas/CI
+- [ ] Otros (especificar)
 
-### Nuevos Tests
-- [ ] **Unit Tests** - Tests para funcionalidades específicas
-- [ ] **Integration Tests** - Tests de integración entre módulos
-- [ ] **Performance Tests** - Tests de rendimiento
-- [ ] **E2E Tests** - Tests end-to-end
-- [ ] **Benchmark Tests** - Benchmarks de rendimiento
+Detalles de los escenarios cubiertos:
+- …
 
-### Tests Actualizados
-- [ ] Tests existentes modificados
-- [ ] Parámetros de tests actualizados
-- [ ] Assertions mejoradas
-
-### Tests Eliminados
-- [ ] Tests obsoletos removidos
-- [ ] Tests duplicados eliminados
-
-## 🎯 Objetivos
-
-### ¿Qué se está probando?
-Describe qué funcionalidad o comportamiento se está validando.
-
-### ¿Por qué son necesarios estos tests?
-- [ ] **Nueva funcionalidad** - Probar features nuevas
-- [ ] **Bug fix** - Prevenir regresiones
-- [ ] **Refactoring** - Validar que la funcionalidad se mantiene
-- [ ] **Performance** - Validar performance constraints
-- [ ] **Edge cases** - Probar casos extremos
-- [ ] **Error handling** - Probar manejo de errores
-
-## 📊 Cobertura
-
-### Módulos Afectados
-- [ ] `veld-annotations`
-- [ ] `veld-runtime`
-- [ ] `veld-processor`
-- [ ] `veld-aop`
-- [ ] `veld-benchmark`
-
-### Cobertura Antes/Después
-- **Cobertura actual**: X%
-- **Cobertura esperada**: Y%
-- **Líneas cubiertas**: +Z líneas
-
-## 🧪 Detalles de Tests
-
-### Nuevos Test Cases
-Describe los casos de prueba específicos que se agregaron.
-
-### Scenarios Cubiertos
-- **Happy path**: Escenario de éxito
-- **Edge cases**: Casos límite
-- **Error scenarios**: Manejo de errores
-- **Performance**: Constraints de rendimiento
-
-### Datos de Prueba
-- [ ] Test data fixtures
-- [ ] Mock objects
-- [ ] Test configuration
-
-## 🔧 Configuración de Tests
-
-### Dependencies
-- [ ] Nuevas dependencias de testing agregadas
-- [ ] Configuración de test frameworks actualizada
-
-### Herramientas Utilizadas
-- [ ] **JUnit** - Tests unitarios
-- [ ] **Mockito** - Mocking framework
-- [ ] **TestContainers** - Integration tests
-- [ ] **JMH** - Performance benchmarks
-- [ ] **Otro**: _______________
-
-## 📈 Resultados de Ejecución
-
-### Local Execution
-```
-✅ Tests ejecutados: X
-❌ Tests fallidos: 0
-⏱️ Tiempo total: Y segundos
-```
-
-### CI Pipeline
-- [ ] Tests pasando en CI
-- [ ] Coverage requirements cumplidos
-- [ ] Performance benchmarks en verde
+## 🧪 Pruebas
+- [ ] Todos los tests pasan localmente
+- [ ] Se ejecutaron suites relevantes en CI
+- [ ] Pruebas manuales (si aplica)
+- [ ] Sin pruebas (explicar)
 
 ## ✅ Checklist
+- [ ] Casos positivos y negativos cubiertos
+- [ ] Datos de prueba representativos
+- [ ] Auto-review completada
+- [ ] Documentación de pruebas actualizada (si aplica)
 
-### Calidad de Tests
-- [ ] Tests son independientes
-- [ ] Tests son determinísticos
-- [ ] Tests tienen nombres descriptivos
-- [ ] Tests incluyen assertions claras
-
-### Mantenibilidad
-- [ ] Código de tests es limpio y legible
-- [ ] Reutilización apropiada de código
-- [ ] Documentation en tests complejos
-
-### Performance
-- [ ] Tests ejecutan en tiempo razonable
-- [ ] No memory leaks en tests
-- [ ] Parallel execution considerada
-
----
-*Test PR template - Revisar [estándares de testing](./CONTRIBUTING.md)*
+## 🔗 Referencias
+- Issue relacionado: #(número del issue)
+- Enlaces a runs de CI: …


### PR DESCRIPTION
## Summary
- align all PR templates to a common structure (summary, changes, tests, checklist, references)
- simplify specialized templates (feature, bug fix, hotfix, refactor, docs, tests) to use the same sections and language
- keep default template consistent with the specialized ones

## Rationale
PR templates had diverged in structure and wording; normalizing them makes contributor guidance consistent and easier to follow.

## Changes
- rewritten templates under .github/PULL_REQUEST_TEMPLATE to share the same sections and checklists in Spanish
- kept quick checkboxes for change type and testing across all templates

## Test Plan
- not run (docs/templates only)

Fixes #105