### PR TITLE
fix: configure veld-maven-plugin for bytecode weaving in veld-example

### DIFF
--- a/veld-example/pom.xml
+++ b/veld-example/pom.xml
@@ -108,13 +108,6 @@
                 <version>3.11.0</version>
                 <configuration>
                     <release>17</release>
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>io.github.yasmramos</groupId>
-                            <artifactId>veld-processor</artifactId>
-                            <version>${project.version}</version>
-                        </path>
-                    </annotationProcessorPaths>
                     <compilerArgs>
                         <arg>--add-opens</arg>
                         <arg>java.base/java.lang=ALL-UNNAMED</arg>
@@ -169,13 +162,17 @@
                 <groupId>io.github.yasmramos</groupId>
                 <artifactId>veld-maven-plugin</artifactId>
                 <version>1.0.3</version>
+                <configuration>
+                    <compile>true</compile>
+                    <verbose>false</verbose>
+                </configuration>
                 <executions>
                     <execution>
                         <id>veld-compile</id>
                         <goals>
                             <goal>compile</goal>
                         </goals>
-                        <phase>compile</phase>
+                        <phase>process-classes</phase>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
- Enable bytecode weaving during process-classes phase
- Add compile configuration to handle injection setter methods
- Resolves 'cannot find symbol' errors for __di_set_... methods