### PR TITLE
fix: resolve #112 — [Enhancement] Improve ConditionEvaluator error messages

### DIFF
--- a/veld-runtime/src/main/java/io/github/yasmramos/veld/runtime/condition/Condition.java
+++ b/veld-runtime/src/main/java/io/github/yasmramos/veld/runtime/condition/Condition.java
@@ -1,0 +1,12 @@
+package io.github.yasmramos.veld.runtime.condition;
+
+public interface Condition {
+
+    boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata);
+
+    default ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata metadata) {
+        boolean match = matches(context, metadata);
+        String message = getClass().getSimpleName() + (match ? " matched" : " did not match");
+        return match ? ConditionOutcome.match(message) : ConditionOutcome.noMatch(message);
+    }
+}

--- a/veld-runtime/src/main/java/io/github/yasmramos/veld/runtime/condition/ConditionOutcome.java
+++ b/veld-runtime/src/main/java/io/github/yasmramos/veld/runtime/condition/ConditionOutcome.java
@@ -1,0 +1,56 @@
+package io.github.yasmramos.veld.runtime.condition;
+
+import java.util.Objects;
+
+public final class ConditionOutcome {
+
+    private final boolean match;
+    private final String message;
+
+    private ConditionOutcome(boolean match, String message) {
+        this.match = match;
+        this.message = Objects.requireNonNull(message, "message must not be null");
+    }
+
+    public static ConditionOutcome match() {
+        return new ConditionOutcome(true, "");
+    }
+
+    public static ConditionOutcome match(String reason) {
+        return new ConditionOutcome(true, reason);
+    }
+
+    public static ConditionOutcome noMatch(String reason) {
+        return new ConditionOutcome(false, reason);
+    }
+
+    public boolean isMatch() {
+        return match;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof ConditionOutcome)) {
+            return false;
+        }
+        ConditionOutcome other = (ConditionOutcome) obj;
+        return match == other.match && message.equals(other.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(match, message);
+    }
+
+    @Override
+    public String toString() {
+        return message;
+    }
+}

--- a/veld-runtime/src/main/java/io/github/yasmramos/veld/runtime/condition/OnBeanCondition.java
+++ b/veld-runtime/src/main/java/io/github/yasmramos/veld/runtime/condition/OnBeanCondition.java
@@ -1,0 +1,60 @@
+package io.github.yasmramos.veld.runtime.condition;
+
+import io.github.yasmramos.veld.core.annotation.ConditionalOnBean;
+import io.github.yasmramos.veld.core.annotation.ConditionalOnMissingBean;
+import io.github.yasmramos.veld.runtime.container.BeanContainer;
+
+import java.lang.reflect.AnnotatedElement;
+import java.util.List;
+
+public class OnBeanCondition implements Condition {
+
+    @Override
+    public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedElement element) {
+        BeanContainer container = context.getContainer();
+
+        ConditionalOnBean onBean = element.getAnnotation(ConditionalOnBean.class);
+        if (onBean != null) {
+            for (Class<?> type : onBean.value()) {
+                List<String> names = container.getBeanNamesForType(type);
+                if (names.isEmpty()) {
+                    return ConditionOutcome.noMatch(String.format(
+                        "Required bean of type '%s' not found in container", type.getName()));
+                }
+            }
+            for (String name : onBean.name()) {
+                if (!container.containsBean(name)) {
+                    return ConditionOutcome.noMatch(String.format(
+                        "Required bean with name '%s' not found in container", name));
+                }
+            }
+            return ConditionOutcome.match();
+        }
+
+        ConditionalOnMissingBean onMissingBean = element.getAnnotation(ConditionalOnMissingBean.class);
+        if (onMissingBean != null) {
+            for (Class<?> type : onMissingBean.value()) {
+                List<String> names = container.getBeanNamesForType(type);
+                if (!names.isEmpty()) {
+                    return ConditionOutcome.noMatch(String.format(
+                        "Bean of type '%s' already registered as '%s'; condition requires it to be absent",
+                        type.getName(), String.join(", ", names)));
+                }
+            }
+            for (String name : onMissingBean.name()) {
+                if (container.containsBean(name)) {
+                    return ConditionOutcome.noMatch(String.format(
+                        "Bean with name '%s' already registered; condition requires it to be absent", name));
+                }
+            }
+            return ConditionOutcome.match();
+        }
+
+        return ConditionOutcome.match();
+    }
+
+    @Override
+    public boolean matches(ConditionContext context, AnnotatedElement element) {
+        return getMatchOutcome(context, element).isMatch();
+    }
+}

--- a/veld-runtime/src/main/java/io/github/yasmramos/veld/runtime/condition/OnClassCondition.java
+++ b/veld-runtime/src/main/java/io/github/yasmramos/veld/runtime/condition/OnClassCondition.java
@@ -1,0 +1,95 @@
+package io.github.yasmramos.veld.runtime.condition;
+
+import io.github.yasmramos.veld.runtime.condition.annotation.ConditionalOnClass;
+import io.github.yasmramos.veld.runtime.condition.annotation.ConditionalOnMissingClass;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class OnClassCondition implements Condition {
+
+    @Override
+    public ConditionOutcome getMatchOutcome(ConditionContext context) {
+        ClassLoader classLoader = context.getClassLoader();
+
+        ConditionalOnClass onClass = context.getAnnotation(ConditionalOnClass.class);
+        if (onClass != null) {
+            List<String> required = collectClassNames(onClass.value(), onClass.name());
+            List<String> missing = new ArrayList<>();
+            for (String className : required) {
+                if (!isPresent(className, classLoader)) {
+                    missing.add(className);
+                }
+            }
+            if (!missing.isEmpty()) {
+                return ConditionOutcome.noMatch(formatMissing(missing));
+            }
+        }
+
+        ConditionalOnMissingClass onMissingClass = context.getAnnotation(ConditionalOnMissingClass.class);
+        if (onMissingClass != null) {
+            List<String> forbidden = collectClassNames(new Class<?>[0], onMissingClass.value());
+            List<String> present = new ArrayList<>();
+            for (String className : forbidden) {
+                if (isPresent(className, classLoader)) {
+                    present.add(className);
+                }
+            }
+            if (!present.isEmpty()) {
+                return ConditionOutcome.noMatch(formatPresent(present));
+            }
+        }
+
+        return ConditionOutcome.match();
+    }
+
+    private List<String> collectClassNames(Class<?>[] classes, String[] names) {
+        List<String> result = new ArrayList<>();
+        if (classes != null) {
+            for (Class<?> c : classes) {
+                result.add(c.getName());
+            }
+        }
+        if (names != null) {
+            for (String n : names) {
+                if (n != null && !n.isEmpty()) {
+                    result.add(n);
+                }
+            }
+        }
+        return result;
+    }
+
+    private boolean isPresent(String className, ClassLoader classLoader) {
+        try {
+            Class.forName(className, false, classLoader);
+            return true;
+        } catch (ClassNotFoundException | LinkageError ex) {
+            return false;
+        }
+    }
+
+    private String formatMissing(List<String> missing) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < missing.size(); i++) {
+            if (i > 0) {
+                sb.append("; ");
+            }
+            sb.append("Required class '").append(missing.get(i))
+                    .append("' not found on classpath (add the corresponding dependency)");
+        }
+        return sb.toString();
+    }
+
+    private String formatPresent(List<String> present) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < present.size(); i++) {
+            if (i > 0) {
+                sb.append("; ");
+            }
+            sb.append("Class '").append(present.get(i))
+                    .append("' was found on classpath but expected to be absent");
+        }
+        return sb.toString();
+    }
+}

--- a/veld-runtime/src/main/java/io/github/yasmramos/veld/runtime/condition/OnPropertyCondition.java
+++ b/veld-runtime/src/main/java/io/github/yasmramos/veld/runtime/condition/OnPropertyCondition.java
@@ -1,0 +1,79 @@
+package io.github.yasmramos.veld.runtime.condition;
+
+import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.annotation.AnnotationAttributes;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class OnPropertyCondition extends SpringBootCondition {
+
+    @Override
+    public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata metadata) {
+        AnnotationAttributes attributes = AnnotationAttributes.fromMap(
+                metadata.getAnnotationAttributes(ConditionalOnProperty.class.getName()));
+        if (attributes == null) {
+            return ConditionOutcome.noMatch("@ConditionalOnProperty annotation not found");
+        }
+
+        String prefix = normalizePrefix(attributes.getString("prefix"));
+        String havingValue = attributes.getString("havingValue");
+        boolean matchIfMissing = attributes.getBoolean("matchIfMissing");
+        String[] names = resolveNames(attributes);
+
+        Environment environment = context.getEnvironment();
+        List<String> mismatches = new ArrayList<>();
+        List<String> missing = new ArrayList<>();
+
+        for (String name : names) {
+            String key = prefix + name;
+            String actual = environment.getProperty(key);
+            if (actual == null) {
+                if (!matchIfMissing) {
+                    missing.add("Property " + key + ": property is missing (matchIfMissing=" + matchIfMissing + ")");
+                }
+            } else if (havingValue != null && !havingValue.isEmpty()) {
+                if (!havingValue.equals(actual)) {
+                    mismatches.add("Property " + key + ": expected \"" + havingValue + "\" but found \"" + actual + "\"");
+                }
+            } else if ("false".equalsIgnoreCase(actual)) {
+                mismatches.add("Property " + key + ": expected \"true\" but found \"" + actual + "\"");
+            }
+        }
+
+        if (mismatches.isEmpty() && missing.isEmpty()) {
+            return ConditionOutcome.match();
+        }
+
+        List<String> reasons = new ArrayList<>(mismatches.size() + missing.size());
+        reasons.addAll(mismatches);
+        reasons.addAll(missing);
+        return ConditionOutcome.noMatch(String.join("; ", reasons));
+    }
+
+    private String normalizePrefix(String prefix) {
+        if (prefix == null || prefix.isEmpty()) {
+            return "";
+        }
+        return prefix.endsWith(".") ? prefix : prefix + ".";
+    }
+
+    private String[] resolveNames(AnnotationAttributes attributes) {
+        String[] value = attributes.getStringArray("value");
+        String[] name = attributes.getStringArray("name");
+        if (value.length > 0 && name.length > 0) {
+            throw new IllegalStateException(
+                    "@ConditionalOnProperty must specify either 'value' or 'name', not both");
+        }
+        if (value.length == 0 && name.length == 0) {
+            throw new IllegalStateException(
+                    "@ConditionalOnProperty must specify at least one property via 'value' or 'name'");
+        }
+        return value.length > 0 ? value : name;
+    }
+}


### PR DESCRIPTION
## Summary

fix: resolve #112 — [Enhancement] Improve ConditionEvaluator error messages

## Problem

**Severity**: `Medium` | **File**: `veld-runtime/src/main/java/io/github/yasmramos/veld/runtime/condition/ConditionOutcome.java`

Introduce a new immutable value type that represents the outcome of evaluating a Condition. It carries a boolean match flag plus a human readable, actionable message describing why the condition matched or failed (expected vs actual, missing property, matchIfMissing flag, suggestions). This is the foundation that lets every Condition return rich diagnostic info instead of a plain boolean.

## Solution

Create a final class `ConditionOutcome` with fields `boolean match` and `String message`. Provide static factories `match(String reason)`, `match()`, `noMatch(String reason)`. Override `toString()` to return the message. Keep the type lightweight (no logging, no nullable message). Place it in package `io.github.yasmramos.veld.runtime.condition` so existing Condition implementations can import it without circular deps.

## Changes

- `veld-runtime/src/main/java/io/github/yasmramos/veld/runtime/condition/ConditionOutcome.java` (new)
- `veld-runtime/src/main/java/io/github/yasmramos/veld/runtime/condition/Condition.java` (new)
- `veld-runtime/src/main/java/io/github/yasmramos/veld/runtime/condition/OnPropertyCondition.java` (new)
- `veld-runtime/src/main/java/io/github/yasmramos/veld/runtime/condition/OnClassCondition.java` (new)
- `veld-runtime/src/main/java/io/github/yasmramos/veld/runtime/condition/OnBeanCondition.java` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
_Note: this change was drafted with AI assistance and reviewed locally before submission._