### PR TITLE
fix: resolve #106 — [Example] Create functional resilience annotations example

### DIFF
--- a/veld-resilience/src/main/java/io/github/yasmramos/veld/resilience/example/ExternalServiceException.java
+++ b/veld-resilience/src/main/java/io/github/yasmramos/veld/resilience/example/ExternalServiceException.java
@@ -1,0 +1,40 @@
+package io.github.yasmramos.veld.resilience.example;
+
+public class ExternalServiceException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public ExternalServiceException(String message) {
+        super(message);
+    }
+
+    public ExternalServiceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public static class TransientException extends ExternalServiceException {
+
+        private static final long serialVersionUID = 1L;
+
+        public TransientException(String message) {
+            super(message);
+        }
+
+        public TransientException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    public static class PermanentException extends ExternalServiceException {
+
+        private static final long serialVersionUID = 1L;
+
+        public PermanentException(String message) {
+            super(message);
+        }
+
+        public PermanentException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/veld-resilience/src/main/java/io/github/yasmramos/veld/resilience/example/FlakyExternalService.java
+++ b/veld-resilience/src/main/java/io/github/yasmramos/veld/resilience/example/FlakyExternalService.java
@@ -1,0 +1,180 @@
+package io.github.yasmramos.veld.resilience.example;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class FlakyExternalService {
+
+    public enum FailureMode {
+        RANDOM,
+        ALWAYS_FAIL,
+        FAIL_FIRST_N,
+        INTERMITTENT
+    }
+
+    public static class ExternalServiceException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+
+        public ExternalServiceException(String message) {
+            super(message);
+        }
+
+        public ExternalServiceException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    private final AtomicInteger callCount = new AtomicInteger(0);
+    private final AtomicInteger failureCount = new AtomicInteger(0);
+    private final AtomicInteger successCount = new AtomicInteger(0);
+    private final AtomicBoolean outage = new AtomicBoolean(false);
+    private final AtomicLong latencyMs = new AtomicLong(0L);
+
+    private volatile FailureMode failureMode = FailureMode.RANDOM;
+    private volatile double failureRate = 0.0;
+    private volatile int failFirstN = 0;
+    private volatile int intermittentEvery = 3;
+
+    public FlakyExternalService() {
+    }
+
+    public FlakyExternalService(FailureMode failureMode) {
+        this.failureMode = failureMode;
+    }
+
+    public static FlakyExternalService alwaysFailing() {
+        FlakyExternalService service = new FlakyExternalService(FailureMode.ALWAYS_FAIL);
+        service.setFailureRate(1.0);
+        return service;
+    }
+
+    public static FlakyExternalService flakyWithRate(double rate) {
+        FlakyExternalService service = new FlakyExternalService(FailureMode.RANDOM);
+        service.setFailureRate(rate);
+        return service;
+    }
+
+    public static FlakyExternalService recoveringAfter(int n) {
+        FlakyExternalService service = new FlakyExternalService(FailureMode.FAIL_FIRST_N);
+        service.setFailFirstN(n);
+        return service;
+    }
+
+    public static FlakyExternalService intermittent(int every) {
+        FlakyExternalService service = new FlakyExternalService(FailureMode.INTERMITTENT);
+        service.setIntermittentEvery(every);
+        return service;
+    }
+
+    public String callApi() {
+        int attempt = callCount.incrementAndGet();
+        System.out.println("[FlakyExternalService] callApi() attempt #" + attempt);
+
+        long delay = latencyMs.get();
+        if (delay > 0L) {
+            try {
+                Thread.sleep(delay);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new ExternalServiceException("Call interrupted while simulating latency", e);
+            }
+        }
+
+        if (outage.get()) {
+            failureCount.incrementAndGet();
+            System.out.println("[FlakyExternalService] Outage active, failing call #" + attempt);
+            throw new ExternalServiceException("Service is currently unavailable (outage)");
+        }
+
+        if (shouldFail(attempt)) {
+            failureCount.incrementAndGet();
+            System.out.println("[FlakyExternalService] Failing call #" + attempt + " (mode=" + failureMode + ")");
+            throw new ExternalServiceException("Simulated failure on call #" + attempt);
+        }
+
+        successCount.incrementAndGet();
+        System.out.println("[FlakyExternalService] Success on call #" + attempt);
+        return "OK#" + attempt;
+    }
+
+    private boolean shouldFail(int attempt) {
+        switch (failureMode) {
+            case ALWAYS_FAIL:
+                return true;
+            case FAIL_FIRST_N:
+                return attempt <= failFirstN;
+            case INTERMITTENT:
+                return intermittentEvery > 0 && (attempt % intermittentEvery == 0);
+            case RANDOM:
+            default:
+                return failureRate > 0.0 && ThreadLocalRandom.current().nextDouble() < failureRate;
+        }
+    }
+
+    public void simulateOutage(boolean active) {
+        outage.set(active);
+        System.out.println("[FlakyExternalService] Outage " + (active ? "started" : "ended"));
+    }
+
+    public void setFailureRate(double rate) {
+        if (rate < 0.0 || rate > 1.0) {
+            throw new IllegalArgumentException("failureRate must be between 0.0 and 1.0");
+        }
+        this.failureRate = rate;
+    }
+
+    public void setLatencyMs(long ms) {
+        if (ms < 0L) {
+            throw new IllegalArgumentException("latencyMs must be >= 0");
+        }
+        this.latencyMs.set(ms);
+    }
+
+    public void setFailureMode(FailureMode mode) {
+        if (mode == null) {
+            throw new IllegalArgumentException("failureMode must not be null");
+        }
+        this.failureMode = mode;
+    }
+
+    public void setFailFirstN(int n) {
+        if (n < 0) {
+            throw new IllegalArgumentException("failFirstN must be >= 0");
+        }
+        this.failFirstN = n;
+    }
+
+    public void setIntermittentEvery(int every) {
+        if (every < 1) {
+            throw new IllegalArgumentException("intermittentEvery must be >= 1");
+        }
+        this.intermittentEvery = every;
+    }
+
+    public int getCallCount() {
+        return callCount.get();
+    }
+
+    public int getFailureCount() {
+        return failureCount.get();
+    }
+
+    public int getSuccessCount() {
+        return successCount.get();
+    }
+
+    public FailureMode getFailureMode() {
+        return failureMode;
+    }
+
+    public void reset() {
+        callCount.set(0);
+        failureCount.set(0);
+        successCount.set(0);
+        outage.set(false);
+        latencyMs.set(0L);
+        System.out.println("[FlakyExternalService] State reset");
+    }
+}

--- a/veld-resilience/src/main/java/io/github/yasmramos/veld/resilience/example/InventoryService.java
+++ b/veld-resilience/src/main/java/io/github/yasmramos/veld/resilience/example/InventoryService.java
@@ -1,0 +1,65 @@
+package io.github.yasmramos.veld.resilience.example;
+
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
+public class InventoryService {
+
+    private final CircuitBreaker circuitBreaker;
+    private final AtomicBoolean remoteHealthy = new AtomicBoolean(true);
+
+    public InventoryService() {
+        CircuitBreakerConfig config = CircuitBreakerConfig.custom()
+                .failureRateThreshold(50)
+                .slidingWindowSize(4)
+                .minimumNumberOfCalls(4)
+                .waitDurationInOpenState(Duration.ofSeconds(2))
+                .permittedNumberOfCallsInHalfOpenState(2)
+                .automaticTransitionFromOpenToHalfOpenEnabled(true)
+                .build();
+
+        CircuitBreakerRegistry registry = CircuitBreakerRegistry.of(config);
+        this.circuitBreaker = registry.circuitBreaker("inventoryService");
+    }
+
+    public CircuitBreaker getCircuitBreaker() {
+        return circuitBreaker;
+    }
+
+    public void setRemoteHealthy(boolean healthy) {
+        this.remoteHealthy.set(healthy);
+    }
+
+    public CircuitBreaker.State getState() {
+        return circuitBreaker.getState();
+    }
+
+    public int checkStock(String productId) {
+        Supplier<Integer> decorated = CircuitBreaker.decorateSupplier(
+                circuitBreaker, () -> remoteCheckStock(productId));
+        try {
+            return decorated.get();
+        } catch (CallNotPermittedException e) {
+            return fallbackStock(productId);
+        } catch (Exception e) {
+            return fallbackStock(productId);
+        }
+    }
+
+    private int remoteCheckStock(String productId) {
+        if (!remoteHealthy.get()) {
+            throw new IllegalStateException("Remote inventory service unavailable");
+        }
+        return Math.abs(productId.hashCode() % 100);
+    }
+
+    private int fallbackStock(String productId) {
+        return 0;
+    }
+}

--- a/veld-resilience/src/main/java/io/github/yasmramos/veld/resilience/example/NotificationService.java
+++ b/veld-resilience/src/main/java/io/github/yasmramos/veld/resilience/example/NotificationService.java
@@ -1,0 +1,21 @@
+package io.github.yasmramos.veld.resilience.example;
+
+import io.github.yasmramos.veld.resilience.annotation.RateLimiter;
+
+public class NotificationService {
+
+    @RateLimiter(name = "emailNotifications", limitForPeriod = 10, limitRefreshPeriodMillis = 1000)
+    public String sendEmail(String recipient, String message) {
+        return "Email sent to " + recipient + ": " + message;
+    }
+
+    @RateLimiter(name = "smsNotifications", limitForPeriod = 5, limitRefreshPeriodMillis = 1000, timeoutMillis = 500)
+    public String sendSms(String phoneNumber, String message) {
+        return "SMS sent to " + phoneNumber + ": " + message;
+    }
+
+    @RateLimiter(name = "pushNotifications", limitForPeriod = 100, limitRefreshPeriodMillis = 60000)
+    public String sendPushNotification(String deviceId, String message) {
+        return "Push notification sent to " + deviceId + ": " + message;
+    }
+}

--- a/veld-resilience/src/main/java/io/github/yasmramos/veld/resilience/example/PaymentService.java
+++ b/veld-resilience/src/main/java/io/github/yasmramos/veld/resilience/example/PaymentService.java
@@ -1,0 +1,71 @@
+package io.github.yasmramos.veld.resilience.example;
+
+import io.github.yasmramos.veld.resilience.annotation.Retry;
+
+import java.io.IOException;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class PaymentService {
+
+    @Retry(maxAttempts = 3)
+    public String chargeCard(String cardId, double amount) {
+        if (ThreadLocalRandom.current().nextInt(10) < 7) {
+            throw new RuntimeException("Transient gateway error");
+        }
+        return "charged:" + cardId + ":" + amount;
+    }
+
+    @Retry(maxAttempts = 5, delay = 200)
+    public String authorizePayment(String orderId) {
+        if (ThreadLocalRandom.current().nextInt(10) < 6) {
+            throw new RuntimeException("Authorization service unavailable");
+        }
+        return "authorized:" + orderId;
+    }
+
+    @Retry(maxAttempts = 4, delay = 100, backoffMultiplier = 2.0)
+    public String capturePayment(String authId) {
+        if (ThreadLocalRandom.current().nextInt(10) < 5) {
+            throw new RuntimeException("Capture temporarily failed");
+        }
+        return "captured:" + authId;
+    }
+
+    @Retry(maxAttempts = 5, delay = 250, backoffMultiplier = 1.5, jitter = 100)
+    public String refundPayment(String transactionId) {
+        if (ThreadLocalRandom.current().nextInt(10) < 5) {
+            throw new RuntimeException("Refund queue saturated");
+        }
+        return "refunded:" + transactionId;
+    }
+
+    @Retry(maxAttempts = 4, delay = 150, retryOn = {IOException.class})
+    public String contactGateway(String endpoint) throws IOException {
+        if (ThreadLocalRandom.current().nextInt(10) < 6) {
+            throw new IOException("Network failure contacting " + endpoint);
+        }
+        return "ok:" + endpoint;
+    }
+
+    @Retry(
+            maxAttempts = 5,
+            delay = 200,
+            backoffMultiplier = 2.0,
+            jitter = 50,
+            retryOn = {IOException.class, RuntimeException.class},
+            abortOn = {IllegalArgumentException.class}
+    )
+    public String processPayment(String orderId, double amount) throws IOException {
+        if (amount <= 0) {
+            throw new IllegalArgumentException("Amount must be positive");
+        }
+        int roll = ThreadLocalRandom.current().nextInt(10);
+        if (roll < 4) {
+            throw new IOException("Gateway timeout for order " + orderId);
+        }
+        if (roll < 7) {
+            throw new RuntimeException("Temporary processing error");
+        }
+        return "processed:" + orderId + ":" + amount;
+    }
+}


### PR DESCRIPTION
## Summary

fix: resolve #106 — [Example] Create functional resilience annotations example

## Problem

**Severity**: `Medium` | **File**: `veld-resilience/src/main/java/io/github/yasmramos/veld/resilience/example/FlakyExternalService.java`

Creates a simulated external service (e.g., a remote API or database) that can be configured to fail with various patterns: intermittent failures, sustained outages, slow responses, and rate-limit-triggering bursts. This is the core dependency the example services will call, providing realistic conditions for resilience patterns to react to.

## Solution

Implement a class with methods like `callApi()`, `simulateOutage(boolean)`, `setFailureRate(double)`, and `setLatencyMs(long)`. Use AtomicInteger counters to track call attempts and a configurable failure mode (RANDOM, ALWAYS_FAIL, FAIL_FIRST_N, INTERMITTENT). Throw a custom `ExternalServiceException` on simulated failures. Include logging via System.out so users can observe call patterns. Provide static factory methods like `alwaysFailing()`, `flakyWithRate(double)`, `recoveringAfter(int)` for scenario setup.

## Changes

- `veld-resilience/src/main/java/io/github/yasmramos/veld/resilience/example/FlakyExternalService.java` (new)
- `veld-resilience/src/main/java/io/github/yasmramos/veld/resilience/example/ExternalServiceException.java` (new)
- `veld-resilience/src/main/java/io/github/yasmramos/veld/resilience/example/PaymentService.java` (new)
- `veld-resilience/src/main/java/io/github/yasmramos/veld/resilience/example/InventoryService.java` (new)
- `veld-resilience/src/main/java/io/github/yasmramos/veld/resilience/example/NotificationService.java` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
_Note: this change was drafted with AI assistance and reviewed locally before submission._